### PR TITLE
Add postgresql enum support

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add support for [PostgreSQL enums](https://www.postgresql.org/docs/10/static/datatype-enum.html): .
+
+    Creating a new enum type:
+
+        create_enum :ebook_format, [:pdf, :epub]
+
+    Droping an enum:
+
+        drop_enum :ebook_format
+
+    Adding a new value to an existing enum:
+
+        add_enum_value :ebook_format, :mobi
+
+    *Antonio Borrero Granell*
+
 *   Fix relation merger issue with `left_outer_joins`.
 
     *Mehmet Emin İNAÇ*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -78,6 +78,19 @@ module ActiveRecord
         views.include?(view_name.to_s)
       end
 
+      # Returns an array of enum names defined in the database.
+      def enums
+        raise NotImplementedError, "#enums is not implemented"
+      end
+
+      # Checks to see if the enum type +enum_name+ exists on the database.
+      #
+      #   enum_exists?(:ebook_format)
+      #
+      def enum_exists?(_enum_name)
+        raise NotImplementedError, "#enum_exists? is not implemented"
+      end
+
       # Returns an array of indexes for the given table.
       def indexes(table_name)
         raise NotImplementedError, "#indexes is not implemented"
@@ -146,6 +159,64 @@ module ActiveRecord
         pk = primary_keys(table_name)
         pk = pk.first unless pk.size > 1
         pk
+      end
+
+      # Creates a new enum type with the name +enum_name+ which possible values are +values+.
+      # +enum_name+ may be either be a String or a Symbol. +values+ is an array of either String or Symbol.
+      #
+      # ====== Creating an enum type
+      #
+      #   create_enum(:ebook_format, [:pdf, :epub, :mobi])
+      #
+      # generates:
+      #
+      #   CREATE TYPE ebook_format AS ENUM ('pdf', 'epub', 'mobi')
+      #
+      # Note: only supported by PostgreSQL
+      def create_enum(enum_name, values)
+        raise NotImplementedError, "#{self.class} does not support enum types"
+      end
+
+      # Drops an enum type with the name +enum_name+ from the database.
+      # +enum_name+ may be either a String or a Symbol.
+      #
+      # ====== Dropping an enum
+      #
+      #   drop_enum(:ebook_format)
+      #
+      # generates:
+      #
+      #   DROP TYPE ebook_format
+      #
+      # Note: only supported by PostgreSQL
+      def drop_enum(enum_name)
+        raise NotImplementedError, "#{self.class} does not support enum types"
+      end
+
+      # Add a new value +value+ to an enum type +enum_name+.
+      # +enum_name+ and +value+ may be either be a String or a Symbol.
+      #
+      # Available options are:
+      # * <tt>:before</tt> -
+      #   Inserts the new value before the specified value.
+      # * <tt>:after</tt> -
+      #   Inserts the new value after the specified value.
+      #
+      # Note: only supported by PostgreSQL
+      #
+      # == Examples
+      #
+      #   add_enum_value(:ebook_format, :html)
+      #   ALTER TYPE ebook_format ADD VALUE 'html'
+      #
+      #   add_enum_value(:ebook_format, :html, before: :pdf)
+      #   ALTER TYPE ebook_format ADD VALUE 'html' BEFORE 'pdf'
+      #
+      #   add_enum_value(:ebook_format, :html, after: :pdf)
+      #   ALTER TYPE ebook_format ADD VALUE 'html' AFTER 'pdf'
+      #
+      def add_enum_value(enum_name, value)
+        raise NotImplementedError, "#{self.class} does not support enum types"
       end
 
       # Creates a new table with the name +table_name+. +table_name+ may either

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -269,6 +269,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support enum types?
+      def supports_enums?
+        false
+      end
+
       # Does this adapter support creating indexes in the same statement as
       # creating the table?
       def supports_indexes_in_create?

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -6,6 +6,20 @@ module ActiveRecord
       class SchemaDumper < ConnectionAdapters::SchemaDumper # :nodoc:
         private
 
+          def enums(stream)
+            sorted_enums = @connection.enums.sort
+
+            sorted_enums.each do |enum_name|
+              enum(enum_name, stream)
+            end
+            stream.print "\n"
+          end
+
+          def enum(enum_name, stream)
+            values = @connection.enum_values(enum_name)
+            stream.puts "  create_enum #{enum_name.inspect}, #{values.inspect}"
+          end
+
           def extensions(stream)
             extensions = @connection.extensions
             if extensions.any?

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -144,6 +144,24 @@ module ActiveRecord
           end
         end
 
+        # Returns an array of enum names defined in the database.
+        def enums
+          query(<<-SQL, "SCHEMA").flatten
+            SELECT DISTINCT t.typname AS enum_name
+            FROM pg_type t
+            JOIN pg_enum e ON t.oid = e.enumtypid
+            JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace;
+          SQL
+        end
+
+        # Checks to see if the enum type +enum_name+ exists on the database.
+        #
+        #   enum_exists?(:ebook_format)
+        #
+        def enum_exists?(enum_name)
+          enums.include?(enum_name)
+        end
+
         def table_options(table_name) # :nodoc:
           if comment = table_comment(table_name)
             { comment: comment }
@@ -494,6 +512,38 @@ module ActiveRecord
           validate_index_length!(table_name, new_name)
 
           execute "ALTER INDEX #{quote_column_name(old_name)} RENAME TO #{quote_table_name(new_name)}"
+        end
+
+        # Creates an enum type with name +enum_name+ which values are +values+.
+        def create_enum(enum_name, values)
+          formatted_values = values.map { |v| "'#{v}'" }.join(", ")
+
+          execute "CREATE TYPE #{enum_name} AS ENUM (#{formatted_values})"
+        end
+
+        # Add a new value to an existing enum which name is +enum_name+.
+        def add_enum_value(enum_name, value, options = {})
+          if options[:before] && options[:after]
+            raise ArgumentError.new("You cannot use before and after options at the same time")
+          end
+
+          sql = "ALTER TYPE #{enum_name} ADD VALUE '#{value}'".dup
+          sql << " BEFORE '#{options[:before]}'" if options[:before]
+          sql << " AFTER '#{options[:after]}'" if options[:after]
+
+          execute sql
+        end
+
+        # Drops an enum type with name +enum_name+ from the database.
+        def drop_enum(enum_name)
+          execute "DROP TYPE #{enum_name}"
+        end
+
+        # Returns the list of values of the enum with name +enum_name+.
+        def enum_values(enum_name)
+          query(<<-SQL, "SCHEMA").flatten
+            SELECT unnest(enum_range(NULL::#{enum_name}))
+          SQL
         end
 
         def foreign_keys(table_name)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -309,6 +309,10 @@ module ActiveRecord
         true
       end
 
+      def supports_enums?
+        true
+      end
+
       def supports_ranges?
         # Range datatypes weren't introduced until PostgreSQL 9.2
         postgresql_version >= 90200

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -11,12 +11,15 @@ module ActiveRecord
     # * add_index
     # * add_reference
     # * add_timestamps
+    # * add_enum_value
     # * change_column
     # * change_column_default (must supply a :from and :to option)
     # * change_column_null
+    # * create_enum
     # * create_join_table
     # * create_table
     # * disable_extension
+    # * drop_enum
     # * drop_join_table
     # * drop_table (must supply a block)
     # * enable_extension
@@ -35,7 +38,8 @@ module ActiveRecord
         :change_column_default, :add_reference, :remove_reference, :transaction,
         :drop_join_table, :drop_table, :execute_block, :enable_extension, :disable_extension,
         :change_column, :execute, :remove_columns, :change_column_null,
-        :add_foreign_key, :remove_foreign_key
+        :add_foreign_key, :remove_foreign_key,
+        :create_enum, :drop_enum, :add_enum_value
       ]
       include JoinTable
 
@@ -221,6 +225,11 @@ module ActiveRecord
           reversed_args << remove_options if remove_options
 
           [:add_foreign_key, reversed_args]
+        end
+
+        def invert_create_enum(args)
+          enum_name = args.first
+          [:drop_enum, enum_name]
         end
 
         def respond_to_missing?(method, _)

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -35,6 +35,7 @@ module ActiveRecord
     def dump(stream)
       header(stream)
       extensions(stream)
+      enums(stream)
       tables(stream)
       trailer(stream)
       stream
@@ -84,6 +85,10 @@ HEADER
 
       # extensions are only supported by PostgreSQL
       def extensions(stream)
+      end
+
+      # enums are only supported by PostgreSQL
+      def enums(stream)
       end
 
       def tables(stream)

--- a/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
@@ -35,6 +35,44 @@ module ActiveRecord
         assert_equal :datetime, column.type
         assert column.array?
       end
+
+      def test_create_enum
+        connection.create_enum "my_enum", ["value1", "value2"]
+        assert_includes connection.enums, "my_enum"
+        assert_equal connection.enum_values("my_enum"), ["value1", "value2"]
+      end
+
+      def test_drop_enum
+        connection.create_enum "my_enum", ["value1", "value2"]
+        assert connection.enum_exists?("my_enum")
+
+        connection.drop_enum "my_enum"
+        assert_not connection.enum_exists?("my_enum")
+      end
+
+      def test_add_enum_value
+        connection.create_enum "my_enum", ["value1", "value2"]
+        assert_equal connection.enum_values("my_enum"), ["value1", "value2"]
+
+        connection.add_enum_value "my_enum", "value3"
+        assert_equal connection.enum_values("my_enum"), ["value1", "value2", "value3"]
+      end
+
+      def test_add_enum_value_with_before
+        connection.create_enum "my_enum", ["value1", "value2"]
+        assert_equal connection.enum_values("my_enum"), ["value1", "value2"]
+
+        connection.add_enum_value "my_enum", "value0", before: "value1"
+        assert_equal connection.enum_values("my_enum"), ["value0", "value1", "value2"]
+      end
+
+      def test_add_enum_value_with_after
+        connection.create_enum "my_enum", ["value1", "value2"]
+        assert_equal connection.enum_values("my_enum"), ["value1", "value2"]
+
+        connection.add_enum_value "my_enum", "value1.5", after: "value1"
+        assert_equal connection.enum_values("my_enum"), ["value1", "value1.5", "value2"]
+      end
     end
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -376,6 +376,14 @@ module ActiveRecord
         end
       end
 
+      def test_supports_extensions
+        assert @connection.supports_extensions?, "does support extensions"
+      end
+
+      def test_supports_enums
+        assert @connection.supports_enums?, "does support enums"
+      end
+
       private
 
         def with_example_table(definition = "id serial primary key, number integer, data character varying(255)", &block)

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -474,6 +474,11 @@ module ActiveRecord
         assert_not @conn.supports_extensions?, "does not support extensions"
       end
 
+
+      def test_supports_enums
+        assert_not @conn.supports_enums?, "does not support enums"
+      end
+
       def test_respond_to_enable_extension
         assert @conn.respond_to?(:enable_extension)
       end

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -108,6 +108,14 @@ module ActiveRecord
         end
       end
 
+      def test_invert_create_enum
+        @recorder.revert do
+          @recorder.record :create_enum, [:ebook_format, [:pdf, :mobi]]
+        end
+        drop_enum = @recorder.commands.first
+        assert_equal [:drop_enum, :ebook_format], drop_enum
+      end
+
       def test_invert_create_table
         @recorder.revert do
           @recorder.record :create_table, [:system_settings]


### PR DESCRIPTION
### Summary

This adds support for [PostgreSQL enum types](https://www.postgresql.org/docs/8.3/static/datatype-enum.html) in migrations and in the ruby schema. 

### Other Information

Adds 3 methods for migrations:

- `create_enum :ebook_format, [:pdf, :epub]`
This would generate
```SQL
CREATE TYPE ebook_format AS ENUM('pdf', 'epub')
```

- `drop_enum :ebook_format`
This would generate
```SQL
DROP TYPE ebook_format
```

- `add_enum_value :ebook_format, :mobi` 
This would generate
```SQL
ALTER TYPE ebook_format ADD VALUE 'mobi'
```
This method also accepts `:before` or `:after`options, to insert the new value in a specific position.

It also adds PostgreSQL enum support for the ruby schema. The would be represented in the schema as:
```ruby
create_enum :ebook_format, values: ['pdf', 'epub']
``` 
